### PR TITLE
ContactsProvider: Prevent device contact being deleted.

### DIFF
--- a/src/com/android/providers/contacts/AccountWithDataSet.java
+++ b/src/com/android/providers/contacts/AccountWithDataSet.java
@@ -62,7 +62,7 @@ public class AccountWithDataSet {
     }
 
     public boolean isLocalAccount() {
-        return (mAccountName == null) && (mAccountType == null);
+        return "DEVICE".equals(mAccountName) && "com.android.contacts".equals(mAccountType);
     }
 
     @Override


### PR DESCRIPTION
Our support for device contact previously was not part of system accounts
neither local device account, So marks it as local device account to
prevent it being stale and deleted.

For reference, see https://github.com/LineageOS/android_packages_providers_ContactsProvider/blob/e3278cf251018fa357eeeb5b4ad838914798a3b4/src/com/android/providers/contacts/ContactsProvider2.java#L5222.

Change-Id: I59b73f3c8556f774da8329c26bfa82119df4d702
Signed-off-by: Toha <tohenk@yahoo.com>